### PR TITLE
try fix router crash problem

### DIFF
--- a/client/lib/open/screens/instance/instance_screen.dart
+++ b/client/lib/open/screens/instance/instance_screen.dart
@@ -84,8 +84,12 @@ class InstanceScreen extends HookConsumerWidget {
           data: (screenData) {
             if (screenData == null) {
               talker.debug("Instance $id not found id DB, redirecting.");
-              HomeScreenRoute().go(context);
-              return null;
+              Future.microtask(() {
+                if (context.mounted) {
+                  HomeScreenRoute().go(context);
+                }
+              });
+              return const SizedBox();
             }
             if (screenData.instance.enterpriseEnabled) {
               return _PullWrapper(

--- a/client/lib/open/screens/instance/widgets/delete_instance_dialog.dart
+++ b/client/lib/open/screens/instance/widgets/delete_instance_dialog.dart
@@ -5,7 +5,6 @@ import 'package:mobile/open/widgets/buttons/dg_button.dart';
 import 'package:mobile/open/widgets/dg_dialog.dart';
 import 'package:mobile/open/widgets/dg_snackbar.dart';
 import 'package:mobile/open/widgets/icons/asset_icons_simple.dart';
-import 'package:mobile/router/routes.dart';
 import 'package:mobile/theme/text.dart';
 
 
@@ -28,7 +27,7 @@ class DeleteInstanceDialog extends HookConsumerWidget {
           .delete();
       if (context.mounted) {
         messenger.showSnackBar(dgSnackBar(text: "Instance deleted"));
-        HomeScreenRoute().go(context);
+        Navigator.of(context).pop();
       }
     }
 


### PR DESCRIPTION
Redirect only on screen data read instead of delete dialog. There is some clash between set state in router and rebuild of screen widget itself and router is not allowed to setState during other builds, this causes router to crash but app itself doesn't and this causes the links from home not working at all.